### PR TITLE
Highlight ruby symbols and heredoc statement

### DIFF
--- a/colors/rubber-enhanced.vim
+++ b/colors/rubber-enhanced.vim
@@ -231,8 +231,11 @@ hi! link twigString String
 
 " Language: Ruby
 " Syntax: 'vim-ruby/vim-ruby'
-hi! link rubyClassName Function
-hi! link rubyModuleName Function
+hi! link rubyClassName        Function
+hi! link rubyModuleName       Function
+hi! link rubySymbol           Number
+hi! link rubyMagicComment     Comment
+hi! link rubyHeredocDelimiter Special
 
 " ============================================================================ "
 " ===                             TERM COLORS                              === "

--- a/colors/rubber-owl.vim
+++ b/colors/rubber-owl.vim
@@ -229,8 +229,11 @@ hi! link twigString String
 
 " Language: Ruby
 " Syntax: 'vim-ruby/vim-ruby'
-hi! link rubyClassName Function
-hi! link rubyModuleName Function
+hi! link rubyClassName        Function
+hi! link rubyModuleName       Function
+hi! link rubySymbol           Number
+hi! link rubyMagicComment     Comment
+hi! link rubyHeredocDelimiter Special
 
 
 " ============================================================================ "

--- a/colors/rubber.vim
+++ b/colors/rubber.vim
@@ -230,8 +230,11 @@ hi! link twigString String
 
 " Language: Ruby
 " Syntax: 'vim-ruby/vim-ruby'
-hi! link rubyClassName Function
-hi! link rubyModuleName Function
+hi! link rubyClassName        Function
+hi! link rubyModuleName       Function
+hi! link rubySymbol           Number
+hi! link rubyMagicComment     Comment
+hi! link rubyHeredocDelimiter Special
 
 
 " ============================================================================ "

--- a/demo/ruby.rb
+++ b/demo/ruby.rb
@@ -11,6 +11,14 @@ class Api::V1::UsersController < ApplicationController
 
   PER_PAGE = 10
 
+  QUERY = <<-SQL
+    SELECT * FROM users;
+  SQL
+
   def index
+    {
+      foo: 1
+      bar: 'abc'
+    }
   end
 end


### PR DESCRIPTION
This commit add Highlight for ruby heredoc
```
<<-SQL
 ....
SQL
```
And for symbols
```
{
  symbol1: 'abc'
}
```
Demo
<img width="1440" alt="2  ruby rb (~: dotfiles:vim:plugged:rubber-themes vim:demo) - NVIM (nvim) 2019-10-04 10-52-27" src="https://user-images.githubusercontent.com/1192122/66184391-54e01d00-e695-11e9-854a-11e574dacbe5.png">

The original theme in sublime
<img width="1552" alt="ruby rb 2019-10-04 10-53-54" src="https://user-images.githubusercontent.com/1192122/66184406-60cbdf00-e695-11e9-905f-61442e374373.png">
